### PR TITLE
Fix deserialise decimal conversion (#55)

### DIFF
--- a/nuql/fields/datetime_timestamp.py
+++ b/nuql/fields/datetime_timestamp.py
@@ -1,7 +1,7 @@
 __all__ = ['DatetimeTimestamp']
 
 from datetime import datetime, UTC
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 import nuql
 from nuql.resources import FieldBase
@@ -31,15 +31,28 @@ class DatetimeTimestamp(FieldBase):
 
     def deserialise(self, value: Decimal | None) -> datetime | None:
         """
-        Deserialises a timestamp to a `datetime`.
+        Deserialises a timestamp-like value to a `datetime`.
 
-        :arg value: `Decimal` instance or `None`.
-        :return: `datetime` instance or `None`.
+        Accepts Decimal, int, float, str, or None.
+        Attempts conversion to Decimal first.
+
+        :arg value: A value representing a timestamp, or None.
+        :return: `datetime` instance or `None` if invalid.
         """
-        if not isinstance(value, Decimal):
+
+        if value is None:
+            return None
+
+        try:
+            # For floats, avoid binary drift by converting via str()
+            if isinstance(value, float):
+                value = Decimal(str(value))
+            else:
+                value = Decimal(value)
+        except (InvalidOperation, TypeError, ValueError):
             return None
 
         try:
             return datetime.fromtimestamp(int(value), UTC)
-        except (ValueError, TypeError):
+        except (ValueError, OSError, OverflowError, TypeError):
             return None


### PR DESCRIPTION
Fixs an issue where the `deserialise` function rejected any value that was not already an instance of `Decimal`.
Implemented attempts to convert any numeric or numeric-string input into a `Decimal` before processing.