### PR TITLE
Added `immutable` field config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,18 @@ db = Nuql(..., custom_fields=[GarbledString])
 There are several configuration options that can be applied to the field dict within your table schema. 
 These options control how the field is serialised and can set several rules:
 
-| Option      | Description                                                                               |
-|-------------|-------------------------------------------------------------------------------------------|
-| `type`      | The field type (required)                                                                 |
-| `required`  | Whether the field is required (enforced only when specifically creating a record)         |
-| `default`   | The default value for the field                                                           |
-| `value`     | Used as a fixed field value, or to configure a `key` field                                |
-| `on_update` | A function that is called to get a value when a record is updated                         |
-| `on_create` | A function that is called to get a value when a record is created                         |
-| `on_write`  | A function that is called to get a value when a record is written (create, update or put) |
-| `validator` | A custom field validator function                                                         |
-| `enum`      | A list of accepted values for the field                                                   |
+| Option      | Description                                                                                        |
+|-------------|----------------------------------------------------------------------------------------------------|
+| `type`      | The field type (required)                                                                          |
+| `required`  | Whether the field is required (enforced only when specifically creating a record)                  |
+| `default`   | The default value for the field                                                                    |
+| `value`     | Used as a fixed field value, or to configure a `key` field                                         |
+| `on_update` | A function that is called to get a value when a record is updated                                  |
+| `on_create` | A function that is called to get a value when a record is created                                  |
+| `on_write`  | A function that is called to get a value when a record is written (create, update or put)          |
+| `validator` | A custom field validator function                                                                  |
+| `enum`      | A list of accepted values for the field                                                            |
+| `immutable` | Whether the field value cannot be changed after creation (only enforced on `UpdateItem` API calls) |
 
 ### Generators
 

--- a/nuql/resources/fields/field.py
+++ b/nuql/resources/fields/field.py
@@ -69,6 +69,10 @@ class FieldBase:
     def enum(self) -> List[Any] | None:
         return self.config.get('enum', None)
 
+    @property
+    def immutable(self) -> bool:
+        return self.config.get('immutable', False)
+
     def __call__(self, value: Any, action: 'types.SerialisationType', validator: 'resources.Validator') -> Any:
         """
         Encapsulates the internal serialisation logic to prepare for

--- a/nuql/resources/records/serialiser.py
+++ b/nuql/resources/records/serialiser.py
@@ -61,6 +61,10 @@ class Serialiser:
                     message=f'Field \'{key}\' is not defined in the schema.'
                 )
 
+            # Skip all changes to immutable fields when using the UpdateItem API
+            if field.immutable and action == 'update':
+                continue
+
             # Skip serialisation for projected fields as this is to be handled at
             # the end of the serialisation process
             if field.projected_from:

--- a/nuql/resources/utils/validators.py
+++ b/nuql/resources/utils/validators.py
@@ -131,7 +131,7 @@ def validate_table(name: str, config: Dict[str, Any], fields: Dict[str, Type['ty
 
         accepted_keys = [
             'type', 'required', 'default', 'value', 'on_create', 'on_update', 'on_write', 'validator', 'enum',
-            'of', 'fields',
+            'of', 'fields', 'immutable'
         ]
         invalid_field_config_keys = [x for x in field_config.keys() if x not in accepted_keys]
         if invalid_field_config_keys:

--- a/nuql/resources/utils/validators.py
+++ b/nuql/resources/utils/validators.py
@@ -129,6 +129,12 @@ def validate_table(name: str, config: Dict[str, Any], fields: Dict[str, Type['ty
                 'message': 'Field key \'enum\' must be a list if provided.'
             }])
 
+        if 'immutable' in field_config and not isinstance(field_config['immutable'], bool):
+            raise nuql.ValidationError([{
+                'name': f'schema.tables.{name}.fields.{field_name}.immutable',
+                'message': 'Field key \'immutable\' must be a boolean value if provided.'
+            }])
+
         accepted_keys = [
             'type', 'required', 'default', 'value', 'on_create', 'on_update', 'on_write', 'validator', 'enum',
             'of', 'fields', 'immutable'

--- a/nuql/types/fields.py
+++ b/nuql/types/fields.py
@@ -25,3 +25,4 @@ class FieldConfig(TypedDict):
     enum: NotRequired[List[Any]]
     of: NotRequired['FieldConfig']
     fields: NotRequired[Dict[str, Any]]
+    immutable: NotRequired[bool]

--- a/nuql/types/fields.py
+++ b/nuql/types/fields.py
@@ -1,6 +1,6 @@
 __all__ = ['FieldConfig', 'IndexType', 'GeneratorCallback', 'ValidatorCallback', 'FieldType']
 
-from typing import TypedDict, NotRequired, Any, Literal, Callable, List, TypeVar, TYPE_CHECKING, Dict
+from typing import TypedDict, NotRequired, Any, Literal, Callable, List, TypeVar, Dict
 
 from nuql import resources
 


### PR DESCRIPTION
### Test Case

```python
from nuql import Nuql
from nuql.generators import Datetime

schema = {
    'test_keys': {
        'pk': {'type': 'key', 'value': {'tenant': '${tenant_id}', 'type': 'test_keys'}},
        'sk': {'type': 'key', 'value': {'id': '${entity_id}'}},
        'ls1': {'type': 'key', 'value': {'customer': '${customer_id}', 'created': '${created_at}'}},
        'created_at': {'type': 'datetime_timestamp', 'on_create': Datetime.now()},
        'tenant_id': {'type': 'ulid', 'required': True},
        'entity_id': {'type': 'ulid', 'required': True},
        'customer_id': {'type': 'string', 'required': True, 'immutable': True},
        'status': {'type': 'string'},
    }
}

indexes = [
    {'hash': 'pk', 'sort': 'sk'},
    {'hash': 'ls1', 'sort': 'created_at', 'type': 'local', 'name': 'ls1-index'}
]

db = Nuql('ls-lib-dev', indexes, schema)


print(db.test_keys.create({
    'tenant_id': '01KC3TF497YB5733J427TD3Q7S',
    'entity_id': '01KC3TF497YB5733J427TD3Q7S',
    'customer_id': '01KC3TF497YB5734J427TD2Q7S',
    'status': 'pending',
}))


print(db.test_keys.update({
    'tenant_id': '01KC3TF497YB5733J427TD3Q7S',
    'entity_id': '01KC3TF497YB5733J427TD3Q7S',
    'customer_id': '01KC3TF497YB5733J427TD2Q7S',
    'status': 'in_progress',
}))
```